### PR TITLE
fix: module indent can be negative

### DIFF
--- a/edu-ws/src/response/content.rs
+++ b/edu-ws/src/response/content.rs
@@ -62,7 +62,7 @@ pub struct Module {
     #[serde(rename = "modplural")]
     pub type_plural: String,
     pub availability: Option<String>,
-    pub indent: u64,
+    pub indent: i64,
     #[serde(rename = "onclick")]
     pub on_click: Option<String>,
     #[serde(rename = "afterlink")]


### PR DESCRIPTION
Synchronization of a course failed, as a module contained a negative indentation (-1) on the WebSite it looks like the indentation 1, but edu-sync doesn't do anything with the indent, so it's not that important.

Fixes #10 
