### PR TITLE
feat: use serde_path_to_error for better parsing errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "serde_repr",
  "serde_with",
  "thiserror 2.0.3",
@@ -1230,6 +1231,16 @@ checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
  "serde",
 ]
 

--- a/edu-ws/Cargo.toml
+++ b/edu-ws/Cargo.toml
@@ -16,6 +16,7 @@ html-escape = "0.2"
 reqwest = { version = "0.12", default-features = false, features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_path_to_error = "0.1"
 serde_repr = "0.1"
 serde_with = "3"
 thiserror = "2"


### PR DESCRIPTION
The parsing errors now use the serde_path_to_error library as I proposed in #11

I'm not too sure on two things:

1. I didn't need (i.e. I couldn't get it working with it, and wasn't too sure what it's use case was with serde) the UntaggedEnumHelper anymore, maybe you can take a look at this if this is correct.

2. I moved printing the response from the `error!` statement to a `debug!` statement for two reasons:
  - `serde_path_to_error` is already descriptive enough: e.g. for the issue that I fixed in #11 It would look like this:
  ```console
  Could not deserialize response err=Error { path: Path { segments: [Seq { index: 6 }, Map { key: "modules" }, Seq { index: 7 }, Map { key: "indent" }] }, original: Error("invalid value: integer `-1`, expected u64", line: 1, column: 35913) }
  ```

   - And the whole response may be rather large and isn't even helpful to the average user, which may even hide the error, if too many things fail and the terminall scrollback history is too small.

This fixes #14 


