### PR TITLE
Fix synchronizing

### DIFF
--- a/edu-sync-cli/src/add.rs
+++ b/edu-sync-cli/src/add.rs
@@ -48,7 +48,7 @@ impl Subcommand {
                 .parse()?
         };
 
-        let expanded_path = config::expand_path(&self.path).await?;
+        let expanded_path = config::expand_path(&self.path)?;
         let account_config = AccountConfig::new(self.url, token, expanded_path, self.lang).await?;
         let mut config = config_task.await??;
         let account_name = account_config.to_string();


### PR DESCRIPTION
Hello :)
Unfortunately with the latest release the software has stopped working (for me?). When deserializing an `AccountConfig` from inside a tokio runtime, the app panics because you can't call `block_on` inside an async execution thread. This would be the case for example when running `edu-sync-cli sync`.

I have made the whole path deserializing synchronous. I don't think it makes a ton of sense to have this asynchronous anyways.